### PR TITLE
Feature/downgrade minsdkversion to kitkat

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,7 +5,7 @@ android {
     compileSdkVersion 27
     defaultConfig {
         applicationId "com.kustomer.kustomer"
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName "1.0"

--- a/kustomersdk/build.gradle
+++ b/kustomersdk/build.gradle
@@ -6,7 +6,7 @@ android {
 
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         targetSdkVersion 27
         versionCode 1
         versionName "0.1.0"

--- a/kustomersdk/src/main/res/drawable/ic_error_outline_red_33dp.xml
+++ b/kustomersdk/src/main/res/drawable/ic_error_outline_red_33dp.xml
@@ -1,4 +1,4 @@
 <vector android:height="33dp" android:viewportHeight="24.0"
     android:viewportWidth="24.0" android:width="33dp" xmlns:android="http://schemas.android.com/apk/res/android">
-    <path android:fillColor="@android:color/holo_red_dark" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
+    <path android:fillColor="#ffcc0000" android:pathData="M11,15h2v2h-2zM11,7h2v6h-2zM11.99,2C6.47,2 2,6.48 2,12s4.47,10 9.99,10C17.52,22 22,17.52 22,12S17.52,2 11.99,2zM12,20c-4.42,0 -8,-3.58 -8,-8s3.58,-8 8,-8 8,3.58 8,8 -3.58,8 -8,8z"/>
 </vector>

--- a/kustomersdk/src/main/res/layout/activity_kussessions.xml
+++ b/kustomersdk/src/main/res/layout/activity_kussessions.xml
@@ -69,7 +69,7 @@
                 android:id="@+id/btnRetry"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:backgroundTint="@android:color/holo_red_dark"
+                android:backgroundTint="#ffcc0000"
                 android:textColor="@android:color/white"
                 android:paddingLeft="20dp"
                 android:paddingRight="20dp"


### PR DESCRIPTION
This branch downgrades the minSdkVersion of the Kustomer SDK to 19.

The only problem to downgrade was the use of an Android resource `@android:color/holo_red_dark` which has been replaced by the value.